### PR TITLE
fix bug that happens when specified file does not exist

### DIFF
--- a/lib/Plack/Middleware/StaticShared.pm
+++ b/lib/Plack/Middleware/StaticShared.pm
@@ -77,14 +77,19 @@ sub call {
 sub concat {
 	my ($self, @files) = @_;
 	my $base = dir($self->base);
-	join("",
-		map {
-			my $file = $base->file($_);
-			$file->resolve;
-			$base->contains($file) ? $file->slurp : '';
-		}
-		@files
-	);
+
+	my $concat = '';
+	for my $f (@files) {
+		my $file = $base->file($f);
+		next unless -e $file;
+
+		$file->resolve;
+		next unless $base->contains($file);
+
+		$concat .= $file->slurp;
+	}
+
+	return $concat;
 }
 
 1;

--- a/t/01-shared.t
+++ b/t/01-shared.t
@@ -123,6 +123,14 @@ test_psgi $m => sub { my $server = shift;
 		done_testing;
 	};
 
+	subtest "contain not exist file" => sub {
+		my $res = $server->(GET "/.shared.js:v1:/js/a.js,/js/b.js,/js/not-exist.js");
+		is $res->code, 200;
+		is $res->header('Content-Type'), 'text/javascript; charset=utf8';
+		ok $res->header('ETag');
+		is $res->content, "aaajs\nbbbjs\n";
+		done_testing;
+	};
 };
 
 done_testing;


### PR DESCRIPTION
```
/.shared.js:v1:/js/a.js,/js/b.js,/js/not-exist.js
```

のように、存在しないファイルを外部から指定された時、Path::Classがresolveの時にエラー終了してしまう問題に対処してみました。
